### PR TITLE
Fix neo4j version

### DIFF
--- a/.atomist/editors/AddNeo.rug
+++ b/.atomist/editors/AddNeo.rug
@@ -46,9 +46,8 @@ with spring.bootProject project begin
 end
 
 with pom begin
-  do addOrReplaceProperty "neo4j.ogm.version" "2.0.5"
-  do addOrReplaceDependencyOfVersion "org.neo4j" "neo4j-ogm-bolt-driver" "${neo4j.ogm.version}"
-  do addOrReplaceDependencyOfVersion "org.neo4j" "neo4j-ogm-embedded-driver" "${neo4j.ogm.version}"
+  do addOrReplaceDependencyOfVersion "org.neo4j" "neo4j-ogm-bolt-driver" "${neo4j-ogm.version}"
+  do addOrReplaceDependencyOfVersion "org.neo4j" "neo4j-ogm-embedded-driver" "${neo4j-ogm.version}"
 end
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<timestamp>${maven.build.timestamp}</timestamp>
-		<neo4j.ogm.version>2.0.5</neo4j.ogm.version>
     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 	</properties>
 
@@ -47,12 +46,12 @@
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-ogm-bolt-driver</artifactId>
-			<version>${neo4j.ogm.version}</version>
+			<version>${neo4j-ogm.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-ogm-embedded-driver</artifactId>
-			<version>${neo4j.ogm.version}</version>
+			<version>${neo4j-ogm.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<timestamp>${maven.build.timestamp}</timestamp>
-    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Since the project uses the spring boot starter already, there is no reason to create another version for Neo4j. The one in Spring Boot is `neo4j-ogm.version` and it can be reused to add additional artifacts.

The added bonus is that such override is going to be transparently handled if the version of Spring Boot changes. Right now, it would require that version to be kept in sync with the Spring Boot version.